### PR TITLE
Set the aces value in the tone-mapping item

### DIFF
--- a/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
+++ b/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
@@ -209,7 +209,7 @@ export class IblSelector extends ConnectedLitElement {
               style="align-self: center; width: 70%;"
               @select=${this.onSelectToneMapping}>
               <paper-item value="neutral">Neutral</paper-item>
-              <paper-item>ACES</paper-item>
+              <paper-item value="aces">ACES</paper-item>
               <paper-item value="agx">AgX</paper-item>
             </me-dropdown>
           </me-section-row>


### PR DESCRIPTION
The “aces” option in the tone mapping selector of the editor is missing a specified value.
